### PR TITLE
Added \displaystyle to input KaTeX

### DIFF
--- a/lib/katex-screenshot.js
+++ b/lib/katex-screenshot.js
@@ -45,8 +45,10 @@ program.action(function main (infile, outfile) {
     let inputKatexStr = fs.readFileSync(infile, 'utf8');
 
     // Parse our KaTeX and built it into our HTML
+    // DEV: Attribution to MathEmbed for \displaystyle tip
+    //   https://github.com/codeOfRobin/MathEmbed/blob/223eb186c92a3000bea641e33839c578851e6393/templates/latex.jade#L12
     let htmlTemplateStr = fs.readFileSync(__dirname + '/renderer/index.html', 'utf8');
-    let inputHtmlStr = katex.renderToString(inputKatexStr);
+    let inputHtmlStr = katex.renderToString(`\\displaystyle{${inputKatexStr}}`);
     assert(htmlTemplateStr.includes('{{input_html}}'));
     let htmlStr = htmlTemplateStr.replace('{{input_html}}', inputHtmlStr);
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "precheck": "twolfson-style precheck lib/ test/",
     "lint": "twolfson-style lint lib/ test/",
-    "test": "mocha --reporter dot && npm run lint"
+    "test": "mocha --reporter dot --timeout 10000 && npm run lint"
   },
   "dependencies": {
     "commander": "~2.11.0",


### PR DESCRIPTION
It looks like our `\displaystyle` change didn't make it into the initial release. This helps make fractions appear as large as their non-fraction counterparts. In this PR:

- Added `\displaystyle` to input KaTeX
- Snuck in a `mocha --timeout` bump to stop timeouts in CI

**Before:**

![image](https://user-images.githubusercontent.com/902488/31849357-f8e91f96-b5f5-11e7-9868-3aa1fbfcd5bf.png)

**After:**

![image](https://user-images.githubusercontent.com/902488/31849361-03d38a04-b5f6-11e7-8f19-1d7ba661c3c4.png)
