### PR TITLE
Upgraded to Electron@1.8.4 to fix GitHub vulnerability warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "commander": "~2.11.0",
-    "electron": "~1.7.9",
+    "electron": "~1.8.4",
     "katex": "~0.9.0-alpha",
     "mkdirp": "~0.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "commander": "~2.11.0",
     "electron": "~1.8.4",
-    "katex": "~0.9.0-alpha",
+    "katex": "~0.8.3",
     "mkdirp": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We've received a warning from GitHub about a vulnerability in `electron`. In this PR:

- Upgraded to Electron@1.8.4 to fix GitHub vulnerability warning